### PR TITLE
Fix app mode persistence between application restarts

### DIFF
--- a/electron/app.storage.ts
+++ b/electron/app.storage.ts
@@ -1,0 +1,55 @@
+import Store from 'electron-store';
+import { AppMode } from '../shared/api';
+import {
+  ELECTRON_STORES,
+  ELECTRON_STORAGE_KEYS,
+  AppStoreSchema,
+} from '../shared/storage';
+
+export interface IAppStore {
+  set(
+    key: keyof AppStoreSchema,
+    value: AppStoreSchema[keyof AppStoreSchema],
+  ): void;
+  get(key: keyof AppStoreSchema): AppStoreSchema[keyof AppStoreSchema];
+  delete(key: keyof AppStoreSchema): void;
+}
+
+const store = new Store<AppStoreSchema>({
+  name: ELECTRON_STORES.APP_SETTINGS,
+  schema: {
+    [ELECTRON_STORAGE_KEYS.APP_SETTINGS.APP_MODE]: {
+      type: ['string', 'null'],
+      default: AppMode.LIVE_INTERVIEW,
+    },
+  },
+}) as unknown as IAppStore;
+
+export class AppStorage {
+  private static instance: AppStorage;
+  private readonly store: IAppStore;
+
+  private constructor() {
+    this.store = store;
+  }
+
+  static getInstance(): AppStorage {
+    if (!AppStorage.instance) {
+      AppStorage.instance = new AppStorage();
+    }
+
+    return AppStorage.instance;
+  }
+
+  setAppMode(appMode: AppMode): void {
+    this.store.set(ELECTRON_STORAGE_KEYS.APP_SETTINGS.APP_MODE, appMode);
+  }
+
+  getAppMode(): AppMode {
+    const storedMode = this.store.get(
+      ELECTRON_STORAGE_KEYS.APP_SETTINGS.APP_MODE,
+    );
+
+    return storedMode || AppMode.LIVE_INTERVIEW;
+  }
+}

--- a/electron/auth.storage.ts
+++ b/electron/auth.storage.ts
@@ -1,9 +1,9 @@
 import Store from 'electron-store';
-
-interface AuthStoreSchema {
-  authToken: string | null;
-  tokenExpiry: number | null;
-}
+import {
+  ELECTRON_STORES,
+  ELECTRON_STORAGE_KEYS,
+  AuthStoreSchema,
+} from '../shared/storage';
 
 export interface IAuthStore {
   set(
@@ -15,14 +15,14 @@ export interface IAuthStore {
 }
 
 const store = new Store<AuthStoreSchema>({
-  name: 'auth',
+  name: ELECTRON_STORES.AUTH,
   schema: {
-    authToken: {
+    [ELECTRON_STORAGE_KEYS.AUTH.TOKEN]: {
       type: 'string',
       nullable: true,
       default: null,
     },
-    tokenExpiry: {
+    [ELECTRON_STORAGE_KEYS.AUTH.TOKEN_EXPIRY]: {
       type: 'number',
       nullable: true,
       default: null,
@@ -47,15 +47,19 @@ export class AuthStorage {
   }
 
   setAuthToken(token: string, expiryTimestamp?: number): void {
-    this.store.set('authToken', token);
+    this.store.set(ELECTRON_STORAGE_KEYS.AUTH.TOKEN, token);
     if (expiryTimestamp) {
-      this.store.set('tokenExpiry', expiryTimestamp);
+      this.store.set(ELECTRON_STORAGE_KEYS.AUTH.TOKEN_EXPIRY, expiryTimestamp);
     }
   }
 
   getAuthToken(): string | null {
-    const token = this.store.get('authToken') as string | null;
-    const expiry = this.store.get('tokenExpiry') as number | null;
+    const token = this.store.get(ELECTRON_STORAGE_KEYS.AUTH.TOKEN) as
+      | string
+      | null;
+    const expiry = this.store.get(ELECTRON_STORAGE_KEYS.AUTH.TOKEN_EXPIRY) as
+      | number
+      | null;
 
     // Check if token has expired
     if (expiry && Date.now() > expiry) {
@@ -68,8 +72,8 @@ export class AuthStorage {
   }
 
   clearAuthToken(): void {
-    this.store.delete('authToken');
-    this.store.delete('tokenExpiry');
+    this.store.delete(ELECTRON_STORAGE_KEYS.AUTH.TOKEN);
+    this.store.delete(ELECTRON_STORAGE_KEYS.AUTH.TOKEN_EXPIRY);
   }
 
   isAuthenticated(): boolean {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -6,6 +6,7 @@ import { ScreenshotHelper } from './screenshot.helper';
 import { ShortcutsHelper } from './shortcuts';
 import { AppMode } from '../shared/api';
 import { WindowConfigFactory } from './window-config/WindowConfigFactory';
+import { AppStorage } from './app.storage';
 import * as dotenv from 'dotenv';
 
 const isDev = !app.isPackaged;
@@ -603,6 +604,12 @@ function loadEnvVariables(): void {
 async function initializeApp() {
   try {
     loadEnvVariables();
+
+    const appStorage = AppStorage.getInstance();
+    const savedAppMode = appStorage.getAppMode();
+    state.appMode = savedAppMode;
+    console.log('Loaded app mode from storage:', savedAppMode);
+
     initializeHelpers();
     initializeIpcHandlers({
       getMainWindow,

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -261,6 +261,7 @@ const electronAPI = {
   authIsAuthenticated: () => ipcRenderer.invoke('auth-is-authenticated'),
   setAppMode: (appMode: AppMode) =>
     ipcRenderer.invoke(IPC_EVENTS.APP_MODE.CHANGE, appMode),
+  getAppMode: () => ipcRenderer.invoke('get-app-mode'),
   writeText: (text: string) => ipcRenderer.invoke('write-text', text),
   copyAndRefreshWindow: (text: string, waitDuration?: number) =>
     ipcRenderer.invoke('copy-and-refresh-window', text, waitDuration),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ezzi",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "dist-electron/main.js",
   "engines": {
     "node": ">=22.0.0"

--- a/shared/storage.ts
+++ b/shared/storage.ts
@@ -1,0 +1,37 @@
+import { AppMode, ProgrammingLanguage, UserLanguage } from './api';
+
+/**
+ * Centralized storage keys and configuration for both Electron and React
+ */
+
+// Electron Store Names
+export const ELECTRON_STORES = {
+  AUTH: 'auth',
+  APP_SETTINGS: 'app-settings',
+} as const;
+
+// Electron Storage Keys
+export const ELECTRON_STORAGE_KEYS = {
+  AUTH: {
+    TOKEN: 'authToken',
+    TOKEN_EXPIRY: 'tokenExpiry',
+  },
+  APP_SETTINGS: {
+    APP_MODE: 'appMode',
+  },
+} as const;
+
+// React localStorage Keys
+export const LOCAL_STORAGE_KEYS = {
+  EZZI_SETTINGS: 'ezzi-settings',
+} as const;
+
+// Storage Schema Types
+export interface AuthStoreSchema {
+  authToken: string | null;
+  tokenExpiry: number | null;
+}
+
+export interface AppStoreSchema {
+  appMode: AppMode | null;
+}

--- a/src/components/shared/AppModeSelector.tsx
+++ b/src/components/shared/AppModeSelector.tsx
@@ -21,23 +21,14 @@ export const AppModeSelector: React.FC<AppModeSelectorProps> = ({
 
   const handleAppModeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const newAppMode = e.target.value as AppMode;
-    storageProvider
-      .setAppMode(newAppMode)
-      .then(() => {
-        setAppMode(newAppMode);
 
-        if (window.electronAPI?.setAppMode) {
-          window.electronAPI.setAppMode(newAppMode).catch((error: any) => {
-            console.error(
-              'Error notifying Electron of app mode change:',
-              error,
-            );
-          });
-        }
-      })
-      .catch((error) => {
-        console.error('Error updating app mode:', error);
+    setAppMode(newAppMode);
+
+    if (!window.electronAPI) {
+      storageProvider.setAppMode(newAppMode).catch((error) => {
+        console.error('Error setting app mode in storage:', error);
       });
+    }
   };
 
   return (

--- a/src/contexts/appMode.tsx
+++ b/src/contexts/appMode.tsx
@@ -29,9 +29,17 @@ export const AppModeProvider: React.FC<AppModeProviderProps> = ({
   useEffect(() => {
     const loadInitialAppMode = async () => {
       try {
-        const storageProvider = getStorageProvider();
-        const storedAppMode = await storageProvider.getAppMode();
-        setCurrentAppMode(storedAppMode);
+        if (window.electronAPI?.getAppMode) {
+          const result = await window.electronAPI.getAppMode();
+          if (result.success && result.appMode) {
+            setCurrentAppMode(result.appMode);
+            console.log('Loaded app mode from Electron:', result.appMode);
+          }
+        } else {
+          const storageProvider = getStorageProvider();
+          const storedAppMode = await storageProvider.getAppMode();
+          setCurrentAppMode(storedAppMode);
+        }
       } catch (error) {
         console.error('Error loading initial app mode:', error);
       }

--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -64,6 +64,11 @@ export interface ElectronAPI {
   setAppMode: (
     appMode: AppMode,
   ) => Promise<{ success: boolean; error?: string }>;
+  getAppMode: () => Promise<{
+    success: boolean;
+    appMode?: AppMode;
+    error?: string;
+  }>;
   writeText: (text: string) => Promise<{ success: boolean; error?: string }>;
   copyAndRefreshWindow: (
     text: string,

--- a/src/services/storage/LocalStorageProvider.ts
+++ b/src/services/storage/LocalStorageProvider.ts
@@ -1,8 +1,9 @@
 import { IStorageProvider, UserSettings } from './StorageProvider';
 import { ProgrammingLanguage, UserLanguage, AppMode } from '@shared/api.ts';
+import { LOCAL_STORAGE_KEYS } from '@shared/storage';
 
 export class LocalStorageProvider implements IStorageProvider {
-  private readonly STORAGE_KEY = 'ezzi-settings';
+  private readonly STORAGE_KEY = LOCAL_STORAGE_KEYS.EZZI_SETTINGS;
 
   getSettings(): Promise<UserSettings> {
     const stored = localStorage.getItem(this.STORAGE_KEY);


### PR DESCRIPTION
Changes

  - Added app.storage.ts using electron-store for persistent app mode storage
  - Created IPC handler get-app-mode to retrieve saved mode on startup
  - Updated React context to load app mode from Electron instead of localStorage
  - Cleaned up duplicate storage calls in AppModeSelector
  - Added shared storage constants in shared/storage.ts
