### PR TITLE
test(coverage): add specs for storage, auth, processors, contexts

### DIFF
--- a/electron/app.storage.spec.ts
+++ b/electron/app.storage.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/unbound-method */
 import { AppMode } from '../shared/api';
 import { AppStorage, type IAppStore } from './app.storage';
 
@@ -11,11 +10,9 @@ jest.mock('electron-store', () => {
 });
 
 function createMockAppStorage() {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   (AppStorage as any).instance = null;
 
   const appStorage = AppStorage.getInstance();
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   const mockStore = (appStorage as any).store as jest.Mocked<IAppStore>;
 
   return { mockStore, appStorage };
@@ -24,7 +21,6 @@ function createMockAppStorage() {
 describe('AppStorage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     (AppStorage as any).instance = null;
   });
 

--- a/electron/app.storage.spec.ts
+++ b/electron/app.storage.spec.ts
@@ -1,0 +1,115 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { AppMode } from '../shared/api';
+import { AppStorage, type IAppStore } from './app.storage';
+
+jest.mock('electron-store', () => {
+  return jest.fn().mockImplementation(() => ({
+    set: jest.fn(),
+    get: jest.fn(),
+    delete: jest.fn(),
+  }));
+});
+
+function createMockAppStorage() {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  (AppStorage as any).instance = null;
+
+  const appStorage = AppStorage.getInstance();
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  const mockStore = (appStorage as any).store as jest.Mocked<IAppStore>;
+
+  return { mockStore, appStorage };
+}
+
+describe('AppStorage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    (AppStorage as any).instance = null;
+  });
+
+  describe('getInstance', () => {
+    test('WHEN getInstance is called twice THEN it returns the same instance', () => {
+      const instance1 = AppStorage.getInstance();
+      const instance2 = AppStorage.getInstance();
+
+      // Assert
+      expect(instance1).toBe(instance2);
+      expect(instance1).toBeInstanceOf(AppStorage);
+    });
+  });
+
+  describe('setAppMode', () => {
+    test('WHEN setAppMode is called THEN it persists the mode', () => {
+      const { mockStore, appStorage } = createMockAppStorage();
+
+      // Act
+      appStorage.setAppMode(AppMode.LEETCODE_SOLVER);
+
+      // Assert
+      expect(mockStore.set).toHaveBeenCalledWith('appMode', AppMode.LEETCODE_SOLVER);
+    });
+  });
+
+  describe('getAppMode', () => {
+    test('WHEN getAppMode is called and mode is stored THEN it returns the stored mode', () => {
+      const { mockStore, appStorage } = createMockAppStorage();
+      mockStore.get.mockReturnValueOnce(AppMode.LEETCODE_SOLVER);
+
+      // Act
+      const result = appStorage.getAppMode();
+
+      // Assert
+      expect(result).toBe(AppMode.LEETCODE_SOLVER);
+      expect(mockStore.get).toHaveBeenCalledWith('appMode');
+    });
+
+    test('WHEN getAppMode is called and no mode is stored THEN it returns LIVE_INTERVIEW default', () => {
+      const { mockStore, appStorage } = createMockAppStorage();
+      mockStore.get.mockReturnValueOnce(null);
+
+      // Act
+      const result = appStorage.getAppMode();
+
+      // Assert
+      expect(result).toBe(AppMode.LIVE_INTERVIEW);
+    });
+  });
+
+  describe('setReadableVarNames', () => {
+    test('WHEN setReadableVarNames is called THEN it persists the boolean', () => {
+      const { mockStore, appStorage } = createMockAppStorage();
+
+      // Act
+      appStorage.setReadableVarNames(true);
+
+      // Assert
+      expect(mockStore.set).toHaveBeenCalledWith('readableVarNames', true);
+    });
+  });
+
+  describe('getReadableVarNames', () => {
+    test('WHEN getReadableVarNames is called and stored value is true THEN it returns true', () => {
+      const { mockStore, appStorage } = createMockAppStorage();
+      mockStore.get.mockReturnValueOnce(true);
+
+      // Act
+      const result = appStorage.getReadableVarNames();
+
+      // Assert
+      expect(result).toBe(true);
+      expect(mockStore.get).toHaveBeenCalledWith('readableVarNames');
+    });
+
+    test('WHEN getReadableVarNames is called and stored value is null THEN it returns false', () => {
+      const { mockStore, appStorage } = createMockAppStorage();
+      mockStore.get.mockReturnValueOnce(null);
+
+      // Act
+      const result = appStorage.getReadableVarNames();
+
+      // Assert
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/electron/auth.storage.spec.ts
+++ b/electron/auth.storage.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/unbound-method */
 import { AuthStorage, type IAuthStore } from './auth.storage';
 
 // Mock electron-store with a factory function
@@ -12,13 +11,11 @@ jest.mock('electron-store', () => {
 
 function createMockAuthStorage() {
   // Reset AuthStorage singleton
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   (AuthStorage as any).instance = null;
 
   // Get reference to the mocked store instance
   const authStorage = AuthStorage.getInstance();
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   const mockStore = (authStorage as any).store as jest.Mocked<IAuthStore>;
 
   return { mockStore, authStorage };
@@ -28,7 +25,6 @@ describe('AuthStorage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     (AuthStorage as any).instance = null;
   });
 

--- a/electron/auth.storage.ts
+++ b/electron/auth.storage.ts
@@ -8,7 +8,6 @@ export interface IAuthStore {
   delete(key: keyof AuthStoreSchema): void;
 }
 
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 const store = new Store<AuthStoreSchema>({
   name: ELECTRON_STORES.AUTH,
   schema: {
@@ -30,7 +29,6 @@ const store = new Store<AuthStoreSchema>({
     },
   },
 }) as unknown as IAuthStore;
-/* eslint-enable @typescript-eslint/no-unsafe-assignment */
 
 export class AuthStorage {
   private static instance: AuthStorage;

--- a/electron/processors/AppModeProcessorFactory.spec.ts
+++ b/electron/processors/AppModeProcessorFactory.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/unbound-method */
 import { AppMode } from '../../shared/api';
 import type { AppModeProcessor } from './AppModeProcessor';
 import { AppModeProcessorFactory } from './AppModeProcessorFactory';
@@ -11,7 +10,6 @@ jest.mock('../../shared/constants', () => ({
 }));
 
 function createFactory(): AppModeProcessorFactory {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   (AppModeProcessorFactory as any).instance = null;
 
   return AppModeProcessorFactory.getInstance();
@@ -20,7 +18,6 @@ function createFactory(): AppModeProcessorFactory {
 describe('AppModeProcessorFactory', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     (AppModeProcessorFactory as any).instance = null;
   });
 

--- a/electron/processors/AppModeProcessorFactory.spec.ts
+++ b/electron/processors/AppModeProcessorFactory.spec.ts
@@ -1,0 +1,85 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { AppMode } from '../../shared/api';
+import type { AppModeProcessor } from './AppModeProcessor';
+import { AppModeProcessorFactory } from './AppModeProcessorFactory';
+import { LeetCodeProcessor } from './LeetCodeProcessor';
+import { LiveInterviewProcessor } from './LiveInterviewProcessor';
+
+jest.mock('../../shared/constants', () => ({
+  API_BASE_URL: 'http://localhost:3000',
+  isSelfHosted: jest.fn(() => false),
+}));
+
+function createFactory(): AppModeProcessorFactory {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  (AppModeProcessorFactory as any).instance = null;
+
+  return AppModeProcessorFactory.getInstance();
+}
+
+describe('AppModeProcessorFactory', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    (AppModeProcessorFactory as any).instance = null;
+  });
+
+  describe('getInstance', () => {
+    test('WHEN getInstance is called twice THEN it returns the same singleton', () => {
+      const a = AppModeProcessorFactory.getInstance();
+      const b = AppModeProcessorFactory.getInstance();
+
+      // Assert
+      expect(a).toBe(b);
+    });
+  });
+
+  describe('getProcessor', () => {
+    test('WHEN appMode is LIVE_INTERVIEW THEN it returns LiveInterviewProcessor', () => {
+      const factory = createFactory();
+
+      // Act
+      const processor = factory.getProcessor(AppMode.LIVE_INTERVIEW);
+
+      // Assert
+      expect(processor).toBeInstanceOf(LiveInterviewProcessor);
+    });
+
+    test('WHEN appMode is LEETCODE_SOLVER THEN it returns LeetCodeProcessor', () => {
+      const factory = createFactory();
+
+      // Act
+      const processor = factory.getProcessor(AppMode.LEETCODE_SOLVER);
+
+      // Assert
+      expect(processor).toBeInstanceOf(LeetCodeProcessor);
+    });
+
+    test('WHEN appMode is unknown THEN it falls back to LiveInterviewProcessor', () => {
+      const factory = createFactory();
+
+      // Act
+      const processor = factory.getProcessor('unknown-mode' as AppMode);
+
+      // Assert
+      expect(processor).toBeInstanceOf(LiveInterviewProcessor);
+    });
+  });
+
+  describe('registerProcessor', () => {
+    test('WHEN a custom processor is registered THEN getProcessor returns it', () => {
+      const factory = createFactory();
+      const customProcessor: AppModeProcessor = {
+        processSolve: jest.fn(),
+        processDebug: jest.fn(),
+      };
+
+      // Act
+      factory.registerProcessor(AppMode.LEETCODE_SOLVER, customProcessor);
+      const result = factory.getProcessor(AppMode.LEETCODE_SOLVER);
+
+      // Assert
+      expect(result).toBe(customProcessor);
+    });
+  });
+});

--- a/electron/processors/AppModeProcessorFactory.ts
+++ b/electron/processors/AppModeProcessorFactory.ts
@@ -28,7 +28,6 @@ export class AppModeProcessorFactory {
     if (!processor) {
       console.warn(`No processor found for app mode: ${appMode}, falling back to LIVE_INTERVIEW`);
 
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       return fallback!;
     }
 

--- a/electron/processors/LeetCodeProcessor.spec.ts
+++ b/electron/processors/LeetCodeProcessor.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/unbound-method */
 import axios from 'axios';
 import type { ProcessingParams } from './AppModeProcessor';
 import { LeetCodeProcessor } from './LeetCodeProcessor';
@@ -20,7 +19,6 @@ function createParams(overrides: Partial<ProcessingParams> = {}): ProcessingPara
   };
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockedAxios = axios as unknown as jest.Mocked<any>;
 const mockedIsCancel = jest.fn();
 
@@ -31,7 +29,6 @@ describe('LeetCodeProcessor', () => {
     jest.clearAllMocks();
     processor = new LeetCodeProcessor();
     mockedIsCancel.mockReturnValue(false);
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     (axios as unknown as { isCancel: jest.Mock }).isCancel = mockedIsCancel;
   });
 

--- a/electron/processors/LeetCodeProcessor.spec.ts
+++ b/electron/processors/LeetCodeProcessor.spec.ts
@@ -1,0 +1,141 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import axios from 'axios';
+import type { ProcessingParams } from './AppModeProcessor';
+import { LeetCodeProcessor } from './LeetCodeProcessor';
+
+jest.mock('axios');
+jest.mock('../../shared/constants', () => ({
+  API_BASE_URL: 'http://localhost:3000',
+  isSelfHosted: jest.fn(() => false),
+}));
+
+function createParams(overrides: Partial<ProcessingParams> = {}): ProcessingParams {
+  return {
+    images: ['data:image/png;base64,xxx'],
+    isMock: false,
+    readableVarNames: false,
+    signal: new AbortController().signal,
+    headers: { 'Content-Type': 'application/json' },
+    ...overrides,
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockedAxios = axios as unknown as jest.Mocked<any>;
+const mockedIsCancel = jest.fn();
+
+describe('LeetCodeProcessor', () => {
+  let processor: LeetCodeProcessor;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    processor = new LeetCodeProcessor();
+    mockedIsCancel.mockReturnValue(false);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    (axios as unknown as { isCancel: jest.Mock }).isCancel = mockedIsCancel;
+  });
+
+  describe('processSolve', () => {
+    test('WHEN request succeeds THEN it returns success with data', async () => {
+      const data = { code: 'class Solution {}', conversationId: 'c1' };
+      mockedAxios.post.mockResolvedValueOnce({ data });
+
+      // Act
+      const result = await processor.processSolve(createParams());
+
+      // Assert
+      expect(result).toEqual({ success: true, data });
+    });
+
+    test('WHEN response is 401 THEN it returns session expired error', async () => {
+      mockedAxios.post.mockRejectedValueOnce({ response: { status: 401 } });
+
+      // Act
+      const result = await processor.processSolve(createParams());
+
+      // Assert
+      expect(result.error).toBe('Your session or subscription has expired. Please sign in again.');
+    });
+
+    test('WHEN response is 402 THEN it returns upgrade error', async () => {
+      mockedAxios.post.mockRejectedValueOnce({ response: { status: 402 } });
+
+      // Act
+      const result = await processor.processSolve(createParams());
+
+      // Assert
+      expect(result.error).toBe(
+        'Upgrade to Pro to generate solutions. Visit getezzi.com to upgrade your plan.',
+      );
+    });
+
+    test('WHEN request is cancelled THEN it returns cancelled error', async () => {
+      mockedIsCancel.mockReturnValueOnce(true);
+      mockedAxios.post.mockRejectedValueOnce(new Error('cancelled'));
+
+      // Act
+      const result = await processor.processSolve(createParams());
+
+      // Assert
+      expect(result.error).toBe('Processing was canceled by the user.');
+    });
+  });
+
+  describe('processDebug', () => {
+    test('WHEN conversationId is missing THEN it short-circuits with helpful error', async () => {
+      // Act
+      const result = await processor.processDebug(createParams());
+
+      // Assert
+      expect(result).toEqual({
+        success: false,
+        error: 'Conversation ID is required for debug requests. Please solve a problem first.',
+      });
+      expect(mockedAxios.post).not.toHaveBeenCalled();
+    });
+
+    test('WHEN conversationId is provided and request succeeds THEN it returns data', async () => {
+      const data = { code: 'fixed', conversationId: 'c1' };
+      mockedAxios.post.mockResolvedValueOnce({ data });
+
+      // Act
+      const result = await processor.processDebug(createParams({ conversationId: 'c1' }));
+
+      // Assert
+      expect(result).toEqual({ success: true, data });
+    });
+
+    test('WHEN response is 401 THEN it returns session expired error', async () => {
+      mockedAxios.post.mockRejectedValueOnce({ response: { status: 401 } });
+
+      // Act
+      const result = await processor.processDebug(createParams({ conversationId: 'c1' }));
+
+      // Assert
+      expect(result.error).toBe('Your session or subscription has expired. Please sign in again.');
+    });
+
+    test('WHEN response is 402 THEN it returns upgrade error', async () => {
+      mockedAxios.post.mockRejectedValueOnce({ response: { status: 402 } });
+
+      // Act
+      const result = await processor.processDebug(createParams({ conversationId: 'c1' }));
+
+      // Assert
+      expect(result.error).toBe(
+        'Upgrade to Pro to generate solutions. Visit getezzi.com to upgrade your plan.',
+      );
+    });
+
+    test('WHEN request is cancelled THEN it returns cancelled error', async () => {
+      mockedIsCancel.mockReturnValueOnce(true);
+      mockedAxios.post.mockRejectedValueOnce(new Error('cancelled'));
+
+      // Act
+      const result = await processor.processDebug(createParams({ conversationId: 'c1' }));
+
+      // Assert
+      expect(result.error).toBe('Processing was canceled by the user.');
+    });
+  });
+});

--- a/electron/processors/LiveInterviewProcessor.spec.ts
+++ b/electron/processors/LiveInterviewProcessor.spec.ts
@@ -1,0 +1,160 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import axios from 'axios';
+import type { ProcessingParams } from './AppModeProcessor';
+import { LiveInterviewProcessor } from './LiveInterviewProcessor';
+
+jest.mock('axios');
+jest.mock('../../shared/constants', () => ({
+  API_BASE_URL: 'http://localhost:3000',
+  isSelfHosted: jest.fn(() => false),
+}));
+
+function createParams(overrides: Partial<ProcessingParams> = {}): ProcessingParams {
+  return {
+    images: ['data:image/png;base64,xxx'],
+    isMock: false,
+    readableVarNames: false,
+    signal: new AbortController().signal,
+    headers: { 'Content-Type': 'application/json' },
+    ...overrides,
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockedAxios = axios as unknown as jest.Mocked<any>;
+const mockedIsCancel = jest.fn();
+
+describe('LiveInterviewProcessor', () => {
+  let processor: LiveInterviewProcessor;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    processor = new LiveInterviewProcessor();
+    mockedIsCancel.mockReturnValue(false);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    (axios as unknown as { isCancel: jest.Mock }).isCancel = mockedIsCancel;
+  });
+
+  describe('processSolve', () => {
+    test('WHEN request succeeds THEN it returns success with data', async () => {
+      const data = {
+        thoughts: ['t1'],
+        code: 'print("hi")',
+        time_complexity: 'O(1)',
+        space_complexity: 'O(1)',
+        problem_statement: 'p',
+        conversationId: 'c1',
+      };
+      mockedAxios.post.mockResolvedValueOnce({ data });
+
+      // Act
+      const result = await processor.processSolve(createParams());
+
+      // Assert
+      expect(result).toEqual({ success: true, data });
+    });
+
+    test('WHEN request is cancelled THEN it returns cancelled error', async () => {
+      const cancelError = new Error('cancelled');
+      mockedIsCancel.mockReturnValueOnce(true);
+      mockedAxios.post.mockRejectedValueOnce(cancelError);
+
+      // Act
+      const result = await processor.processSolve(createParams());
+
+      // Assert
+      expect(result).toEqual({
+        success: false,
+        error: 'Processing was canceled by the user.',
+      });
+    });
+
+    test('WHEN response is 401 THEN it returns session expired error', async () => {
+      mockedAxios.post.mockRejectedValueOnce({ response: { status: 401 } });
+
+      // Act
+      const result = await processor.processSolve(createParams());
+
+      // Assert
+      expect(result).toEqual({
+        success: false,
+        error: 'Your session or subscription has expired. Please sign in again.',
+      });
+    });
+
+    test('WHEN response is 402 THEN it returns upgrade error', async () => {
+      mockedAxios.post.mockRejectedValueOnce({ response: { status: 402 } });
+
+      // Act
+      const result = await processor.processSolve(createParams());
+
+      // Assert
+      expect(result).toEqual({
+        success: false,
+        error: 'Upgrade to Pro to generate solutions. Visit getezzi.com to upgrade your plan.',
+      });
+    });
+
+    test('WHEN error is generic Error THEN it returns its message', async () => {
+      mockedAxios.post.mockRejectedValueOnce(new Error('network down'));
+
+      // Act
+      const result = await processor.processSolve(createParams());
+
+      // Assert
+      expect(result).toEqual({ success: false, error: 'network down' });
+    });
+  });
+
+  describe('processDebug', () => {
+    test('WHEN request succeeds THEN it returns success with data', async () => {
+      const data = {
+        code: 'fixed',
+        thoughts: ['t'],
+        time_complexity: 'O(n)',
+        space_complexity: 'O(n)',
+        conversationId: 'c2',
+      };
+      mockedAxios.post.mockResolvedValueOnce({ data });
+
+      // Act
+      const result = await processor.processDebug(createParams());
+
+      // Assert
+      expect(result).toEqual({ success: true, data });
+    });
+
+    test('WHEN response is 401 THEN it returns session expired error', async () => {
+      mockedAxios.post.mockRejectedValueOnce({ response: { status: 401 } });
+
+      // Act
+      const result = await processor.processDebug(createParams());
+
+      // Assert
+      expect(result.error).toBe('Your session or subscription has expired. Please sign in again.');
+    });
+
+    test('WHEN response is 402 THEN it returns upgrade error', async () => {
+      mockedAxios.post.mockRejectedValueOnce({ response: { status: 402 } });
+
+      // Act
+      const result = await processor.processDebug(createParams());
+
+      // Assert
+      expect(result.error).toBe(
+        'Upgrade to Pro to generate solutions. Visit getezzi.com to upgrade your plan.',
+      );
+    });
+
+    test('WHEN request is cancelled THEN it returns cancelled error', async () => {
+      mockedIsCancel.mockReturnValueOnce(true);
+      mockedAxios.post.mockRejectedValueOnce(new Error('cancelled'));
+
+      // Act
+      const result = await processor.processDebug(createParams());
+
+      // Assert
+      expect(result.error).toBe('Processing was canceled by the user.');
+    });
+  });
+});

--- a/electron/processors/LiveInterviewProcessor.spec.ts
+++ b/electron/processors/LiveInterviewProcessor.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/unbound-method */
 import axios from 'axios';
 import type { ProcessingParams } from './AppModeProcessor';
 import { LiveInterviewProcessor } from './LiveInterviewProcessor';
@@ -20,7 +19,6 @@ function createParams(overrides: Partial<ProcessingParams> = {}): ProcessingPara
   };
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockedAxios = axios as unknown as jest.Mocked<any>;
 const mockedIsCancel = jest.fn();
 
@@ -31,7 +29,6 @@ describe('LiveInterviewProcessor', () => {
     jest.clearAllMocks();
     processor = new LiveInterviewProcessor();
     mockedIsCancel.mockReturnValue(false);
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     (axios as unknown as { isCancel: jest.Mock }).isCancel = mockedIsCancel;
   });
 

--- a/electron/window-config/WindowConfigFactory.spec.ts
+++ b/electron/window-config/WindowConfigFactory.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/unbound-method */
 import { AppMode } from '../../shared/api';
 import { LeetCodeSolverConfig } from './configs/LeetCodeSolverConfig';
 import { LiveInterviewConfig } from './configs/LiveInterviewConfig';
@@ -6,7 +5,6 @@ import { WindowConfigFactory } from './WindowConfigFactory';
 
 describe('WindowConfigFactory', () => {
   beforeEach(() => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     (WindowConfigFactory as any).instance = null;
   });
 

--- a/electron/window-config/WindowConfigFactory.spec.ts
+++ b/electron/window-config/WindowConfigFactory.spec.ts
@@ -1,0 +1,54 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { AppMode } from '../../shared/api';
+import { LeetCodeSolverConfig } from './configs/LeetCodeSolverConfig';
+import { LiveInterviewConfig } from './configs/LiveInterviewConfig';
+import { WindowConfigFactory } from './WindowConfigFactory';
+
+describe('WindowConfigFactory', () => {
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    (WindowConfigFactory as any).instance = null;
+  });
+
+  describe('getInstance', () => {
+    test('WHEN getInstance is called twice THEN it returns the same singleton', () => {
+      const a = WindowConfigFactory.getInstance();
+      const b = WindowConfigFactory.getInstance();
+
+      // Assert
+      expect(a).toBe(b);
+    });
+  });
+
+  describe('getConfig', () => {
+    test('WHEN appMode is LIVE_INTERVIEW THEN it returns LiveInterviewConfig', () => {
+      const factory = WindowConfigFactory.getInstance();
+
+      // Act
+      const config = factory.getConfig(AppMode.LIVE_INTERVIEW);
+
+      // Assert
+      expect(config).toBe(LiveInterviewConfig);
+    });
+
+    test('WHEN appMode is LEETCODE_SOLVER THEN it returns LeetCodeSolverConfig', () => {
+      const factory = WindowConfigFactory.getInstance();
+
+      // Act
+      const config = factory.getConfig(AppMode.LEETCODE_SOLVER);
+
+      // Assert
+      expect(config).toBe(LeetCodeSolverConfig);
+    });
+
+    test('WHEN appMode is unknown THEN it falls back to LiveInterviewConfig', () => {
+      const factory = WindowConfigFactory.getInstance();
+
+      // Act
+      const config = factory.getConfig('mystery' as AppMode);
+
+      // Assert
+      expect(config).toBe(LiveInterviewConfig);
+    });
+  });
+});

--- a/src/App.spec.tsx
+++ b/src/App.spec.tsx
@@ -1,8 +1,3 @@
-/* eslint-disable @typescript-eslint/unbound-method */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-return */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-
 import { isSelfHosted } from '@shared/constants';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -42,9 +37,7 @@ jest.mock('./contexts/SettingsContext', () => ({
 
 jest.mock('./pages/SubscribedApp', () => {
   return function MockSubscribedApp() {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment
     const { useSettings } = require('./contexts/SettingsContext');
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const settings = useSettings();
 
     return (

--- a/src/components/shared/LanguageSelector.tsx
+++ b/src/components/shared/LanguageSelector.tsx
@@ -18,7 +18,6 @@ const LANGUAGE_LABELS: Record<ProgrammingLanguage, string> = {
   [ProgrammingLanguage.PHP]: 'PHP',
 };
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 type LanguageSelectorProps = {};
 
 export const LanguageSelector: React.FC<LanguageSelectorProps> = () => {

--- a/src/components/shared/LocaleSelector.tsx
+++ b/src/components/shared/LocaleSelector.tsx
@@ -24,7 +24,6 @@ const LANGUAGE_LABELS: Record<UserLanguage, string> = {
   [UserLanguage.AR_EG]: 'العربية (EG)',
 };
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 type LocaleSelectorProps = {};
 
 export const LocaleSelector: React.FC<LocaleSelectorProps> = () => {

--- a/src/contexts/ScreenshotContext.spec.tsx
+++ b/src/contexts/ScreenshotContext.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/unbound-method */
-
 import { act, renderHook, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import type { Screenshot } from '../../shared/api';
@@ -17,7 +15,6 @@ describe('ScreenshotContext', () => {
     window.electronAPI = {
       ...window.electronAPI,
       clearAllScreenshots: jest.fn().mockResolvedValue({ success: true }),
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
   });
 

--- a/src/contexts/ScreenshotContext.spec.tsx
+++ b/src/contexts/ScreenshotContext.spec.tsx
@@ -1,0 +1,111 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import type { Screenshot } from '../../shared/api';
+import { ScreenshotProvider, useScreenshotContext } from './ScreenshotContext';
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <ScreenshotProvider>{children}</ScreenshotProvider>;
+}
+
+const sample: Screenshot = { path: '/tmp/a.png', preview: 'data:image/png;base64,xxx' };
+
+describe('ScreenshotContext', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.electronAPI = {
+      ...window.electronAPI,
+      clearAllScreenshots: jest.fn().mockResolvedValue({ success: true }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+  });
+
+  describe('setScreenshots', () => {
+    test('WHEN setScreenshots is called THEN state.screenshots reflects the payload', () => {
+      const { result } = renderHook(() => useScreenshotContext(), { wrapper });
+
+      // Act
+      act(() => {
+        result.current.setScreenshots([sample]);
+      });
+
+      // Assert
+      expect(result.current.state.screenshots).toEqual([sample]);
+    });
+  });
+
+  describe('clearScreenshots', () => {
+    test('WHEN clearScreenshots is called THEN it empties the queue', () => {
+      const { result } = renderHook(() => useScreenshotContext(), { wrapper });
+      act(() => result.current.setScreenshots([sample]));
+
+      // Act
+      act(() => result.current.clearScreenshots());
+
+      // Assert
+      expect(result.current.state.screenshots).toEqual([]);
+    });
+  });
+
+  describe('deleteScreenshot', () => {
+    test('WHEN deleteScreenshot is called THEN target index is removed from list', () => {
+      const { result } = renderHook(() => useScreenshotContext(), { wrapper });
+      const second: Screenshot = { path: '/tmp/b.png', preview: 'p' };
+      act(() => result.current.setScreenshots([sample, second]));
+
+      // Act
+      act(() => result.current.deleteScreenshot(0));
+
+      // Assert
+      expect(result.current.state.screenshots).toEqual([second]);
+    });
+  });
+
+  describe('clearAllScreenshots', () => {
+    test('WHEN IPC succeeds THEN local list is emptied', async () => {
+      const { result } = renderHook(() => useScreenshotContext(), { wrapper });
+      act(() => result.current.setScreenshots([sample]));
+
+      // Act
+      await act(async () => {
+        await result.current.clearAllScreenshots();
+      });
+
+      // Assert
+      expect(window.electronAPI.clearAllScreenshots).toHaveBeenCalled();
+      expect(result.current.state.screenshots).toEqual([]);
+    });
+
+    test('WHEN IPC fails THEN local list is left intact', async () => {
+      (window.electronAPI.clearAllScreenshots as jest.Mock).mockResolvedValueOnce({
+        success: false,
+        error: 'fs busy',
+      });
+      const { result } = renderHook(() => useScreenshotContext(), { wrapper });
+      act(() => result.current.setScreenshots([sample]));
+
+      // Act
+      await act(async () => {
+        await result.current.clearAllScreenshots();
+      });
+
+      // Assert
+      await waitFor(() => {
+        expect(result.current.state.screenshots).toEqual([sample]);
+      });
+    });
+  });
+
+  describe('setLoading', () => {
+    test('WHEN setLoading toggles THEN state.loading reflects the value', () => {
+      const { result } = renderHook(() => useScreenshotContext(), { wrapper });
+
+      // Act
+      act(() => result.current.setLoading(true));
+
+      // Assert
+      expect(result.current.state.loading).toBe(true);
+    });
+  });
+});

--- a/src/contexts/SolutionContext.spec.tsx
+++ b/src/contexts/SolutionContext.spec.tsx
@@ -1,0 +1,121 @@
+import { act, renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import type {
+  DebugResponse,
+  LeetCodeDebugResponse,
+  LeetCodeSolveResponse,
+  SolveResponse,
+} from '../../shared/api';
+import { SolutionProvider, useSolutionContext } from './SolutionContext';
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <SolutionProvider>{children}</SolutionProvider>;
+}
+
+const solve: SolveResponse = {
+  thoughts: ['t'],
+  code: 'print(1)',
+  time_complexity: 'O(1)',
+  space_complexity: 'O(1)',
+  problem_statement: 'p',
+  conversationId: 'c',
+};
+
+const debug: DebugResponse = {
+  code: 'fixed',
+  thoughts: ['t'],
+  time_complexity: 'O(n)',
+  space_complexity: 'O(n)',
+  conversationId: 'c',
+};
+
+const leetSolve: LeetCodeSolveResponse = { code: 'class', conversationId: 'c' };
+const leetDebug: LeetCodeDebugResponse = { code: 'fixed-leet', conversationId: 'c' };
+
+describe('SolutionContext', () => {
+  describe('setSolution', () => {
+    test('WHEN setSolution is called with SolveResponse THEN state.solution is set', () => {
+      const { result } = renderHook(() => useSolutionContext(), { wrapper });
+
+      // Act
+      act(() => result.current.setSolution(solve));
+
+      // Assert
+      expect(result.current.state.solution).toEqual(solve);
+    });
+
+    test('WHEN setSolution is called with LeetCodeSolveResponse THEN state.solution is set', () => {
+      const { result } = renderHook(() => useSolutionContext(), { wrapper });
+
+      // Act
+      act(() => result.current.setSolution(leetSolve));
+
+      // Assert
+      expect(result.current.state.solution).toEqual(leetSolve);
+    });
+  });
+
+  describe('setNewSolution', () => {
+    test('WHEN setNewSolution is called with DebugResponse THEN state.newSolution is set', () => {
+      const { result } = renderHook(() => useSolutionContext(), { wrapper });
+
+      // Act
+      act(() => result.current.setNewSolution(debug));
+
+      // Assert
+      expect(result.current.state.newSolution).toEqual(debug);
+    });
+
+    test('WHEN setNewSolution is called with LeetCodeDebugResponse THEN state.newSolution is set', () => {
+      const { result } = renderHook(() => useSolutionContext(), { wrapper });
+
+      // Act
+      act(() => result.current.setNewSolution(leetDebug));
+
+      // Assert
+      expect(result.current.state.newSolution).toEqual(leetDebug);
+    });
+  });
+
+  describe('clearSolution', () => {
+    test('WHEN clearSolution is called THEN state.solution becomes null', () => {
+      const { result } = renderHook(() => useSolutionContext(), { wrapper });
+      act(() => result.current.setSolution(solve));
+
+      // Act
+      act(() => result.current.clearSolution());
+
+      // Assert
+      expect(result.current.state.solution).toBeNull();
+    });
+  });
+
+  describe('clearNewSolution', () => {
+    test('WHEN clearNewSolution is called THEN state.newSolution becomes null', () => {
+      const { result } = renderHook(() => useSolutionContext(), { wrapper });
+      act(() => result.current.setNewSolution(debug));
+
+      // Act
+      act(() => result.current.clearNewSolution());
+
+      // Assert
+      expect(result.current.state.newSolution).toBeNull();
+    });
+  });
+
+  describe('clearAll', () => {
+    test('WHEN clearAll is called THEN both solution and newSolution become null', () => {
+      const { result } = renderHook(() => useSolutionContext(), { wrapper });
+      act(() => {
+        result.current.setSolution(solve);
+        result.current.setNewSolution(debug);
+      });
+
+      // Act
+      act(() => result.current.clearAll());
+
+      // Assert
+      expect(result.current.state).toEqual({ solution: null, newSolution: null });
+    });
+  });
+});

--- a/src/hooks/useScreenshotEvents.ts
+++ b/src/hooks/useScreenshotEvents.ts
@@ -12,7 +12,6 @@ export function useScreenshotEvents(options: UseScreenshotEventsOptions = {}) {
 
     if (options.onScreenshotTaken || options.refetch) {
       cleanupFunctions.push(
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         window.electronAPI.onScreenshotTaken(async () => {
           options.onScreenshotTaken?.();
           await options.refetch?.();
@@ -22,7 +21,6 @@ export function useScreenshotEvents(options: UseScreenshotEventsOptions = {}) {
 
     if (options.onResetView || options.refetch) {
       cleanupFunctions.push(
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         window.electronAPI.onResetView(async () => {
           options.onResetView?.();
           await options.refetch?.();

--- a/src/hooks/useSolutions.ts
+++ b/src/hooks/useSolutions.ts
@@ -123,7 +123,6 @@ export function useSolutions() {
       }),
       window.electronAPI.onDebugStart(() => setDebugProcessing(true)),
       window.electronAPI.onDebugSuccess((data: any) => {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         setNewSolution(data);
         setDebugProcessing(false);
         void clearAllScreenshots();

--- a/src/services/auth.spec.ts
+++ b/src/services/auth.spec.ts
@@ -1,0 +1,161 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { API_ENDPOINTS, type AuthenticatedUser, SubscriptionLevel } from '../../shared/api';
+import { authService } from './auth';
+
+jest.mock('../config', () => ({
+  API_BASE_URL: 'http://localhost:3000',
+}));
+
+jest.mock('axios');
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const axios = require('axios') as jest.Mocked<typeof import('axios').default>;
+
+function createUser(): AuthenticatedUser {
+  return {
+    user: { email: 'a@b' },
+    subscription: {
+      active_from: '2024-01-01T00:00:00Z',
+      active_to: null,
+      level: SubscriptionLevel.PRO,
+    },
+    settings: {
+      solutionLanguage: 'python' as AuthenticatedUser['settings']['solutionLanguage'],
+      userLanguage: 'en-US' as AuthenticatedUser['settings']['userLanguage'],
+    },
+  };
+}
+
+describe('authService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.electronAPI = {
+      ...window.electronAPI,
+      authSetToken: jest.fn().mockResolvedValue({ success: true }),
+      authClearToken: jest.fn().mockResolvedValue({ success: true }),
+      authGetToken: jest.fn().mockResolvedValue({ success: true, token: 'tok' }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+  });
+
+  describe('login', () => {
+    test('WHEN login is called THEN it posts credentials and returns response data', async () => {
+      const responseData = { data: { user: { email: 'a@b' }, session: null }, error: null };
+      axios.post.mockResolvedValueOnce({ data: responseData });
+
+      // Act
+      const result = await authService.login('a@b', 'pw');
+
+      // Assert
+      expect(result).toEqual(responseData);
+      expect(axios.post).toHaveBeenCalledWith(
+        `http://localhost:3000${API_ENDPOINTS.AUTH.LOGIN}`,
+        { email: 'a@b', password: 'pw' },
+        { timeout: 15000 },
+      );
+    });
+  });
+
+  describe('signUp', () => {
+    test('WHEN signUp is called THEN it forwards data and error from response', async () => {
+      const apiResponse = {
+        data: { user: { email: 'a@b' }, session: null },
+        error: null,
+      };
+      axios.post.mockResolvedValueOnce({ data: apiResponse });
+
+      // Act
+      const result = await authService.signUp('a@b', 'pw');
+
+      // Assert
+      expect(result).toEqual(apiResponse);
+    });
+  });
+
+  describe('getCurrentUser', () => {
+    test('WHEN no token is available THEN it returns null without calling API', async () => {
+      (window.electronAPI.authGetToken as jest.Mock).mockResolvedValueOnce({
+        success: true,
+        token: null,
+      });
+
+      // Act
+      const result = await authService.getCurrentUser();
+
+      // Assert
+      expect(result).toBeNull();
+      expect(axios.get).not.toHaveBeenCalled();
+    });
+
+    test('WHEN token exists THEN it returns the user from API', async () => {
+      const user = createUser();
+      axios.get.mockResolvedValueOnce({ data: user });
+
+      // Act
+      const result = await authService.getCurrentUser();
+
+      // Assert
+      expect(result).toEqual(user);
+      expect(axios.get).toHaveBeenCalledWith(
+        `http://localhost:3000${API_ENDPOINTS.AUTH.USER}`,
+        expect.objectContaining({
+          headers: { Authorization: 'Bearer tok' },
+          timeout: 15000,
+        }),
+      );
+    });
+
+    test('WHEN API call rejects THEN it returns null', async () => {
+      axios.get.mockRejectedValueOnce(new Error('boom'));
+
+      // Act
+      const result = await authService.getCurrentUser();
+
+      // Assert
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getAuthToken', () => {
+    test('WHEN electronAPI returns token THEN it returns the token', async () => {
+      // Act
+      const token = await authService.getAuthToken();
+
+      // Assert
+      expect(token).toBe('tok');
+    });
+
+    test('WHEN electronAPI returns no token THEN it returns null', async () => {
+      (window.electronAPI.authGetToken as jest.Mock).mockResolvedValueOnce({
+        success: true,
+        token: undefined,
+      });
+
+      // Act
+      const token = await authService.getAuthToken();
+
+      // Assert
+      expect(token).toBeNull();
+    });
+
+    test('WHEN electronAPI throws THEN it returns null', async () => {
+      (window.electronAPI.authGetToken as jest.Mock).mockRejectedValueOnce(new Error('ipc fail'));
+
+      // Act
+      const token = await authService.getAuthToken();
+
+      // Assert
+      expect(token).toBeNull();
+    });
+  });
+
+  describe('clearAuthToken', () => {
+    test('WHEN clearAuthToken is called THEN it invokes electronAPI.authClearToken', async () => {
+      // Act
+      await authService.clearAuthToken();
+
+      // Assert
+      expect(window.electronAPI.authClearToken).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/services/auth.spec.ts
+++ b/src/services/auth.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/unbound-method */
 import { API_ENDPOINTS, type AuthenticatedUser, SubscriptionLevel } from '../../shared/api';
 import { authService } from './auth';
 
@@ -8,7 +7,6 @@ jest.mock('../config', () => ({
 
 jest.mock('axios');
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const axios = require('axios') as jest.Mocked<typeof import('axios').default>;
 
 function createUser(): AuthenticatedUser {
@@ -34,7 +32,6 @@ describe('authService', () => {
       authSetToken: jest.fn().mockResolvedValue({ success: true }),
       authClearToken: jest.fn().mockResolvedValue({ success: true }),
       authGetToken: jest.fn().mockResolvedValue({ success: true, token: 'tok' }),
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
   });
 

--- a/src/services/auth/SelfHostedAuthProvider.spec.ts
+++ b/src/services/auth/SelfHostedAuthProvider.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/unbound-method */
 import { AppMode, ProgrammingLanguage, SubscriptionLevel, UserLanguage } from '../../../shared/api';
 import { getStorageProvider } from '../storage';
 import { SelfHostedAuthProvider } from './SelfHostedAuthProvider';

--- a/src/services/auth/SelfHostedAuthProvider.spec.ts
+++ b/src/services/auth/SelfHostedAuthProvider.spec.ts
@@ -1,0 +1,93 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { AppMode, ProgrammingLanguage, SubscriptionLevel, UserLanguage } from '../../../shared/api';
+import { getStorageProvider } from '../storage';
+import { SelfHostedAuthProvider } from './SelfHostedAuthProvider';
+
+jest.mock('../storage', () => ({
+  getStorageProvider: jest.fn(),
+}));
+
+describe('SelfHostedAuthProvider', () => {
+  let provider: SelfHostedAuthProvider;
+  let mockStorage: { getSettings: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    provider = new SelfHostedAuthProvider();
+    mockStorage = {
+      getSettings: jest.fn().mockResolvedValue({
+        solutionLanguage: ProgrammingLanguage.JavaScript,
+        userLanguage: UserLanguage.ES_ES,
+        appMode: AppMode.LIVE_INTERVIEW,
+      }),
+    };
+    (getStorageProvider as jest.Mock).mockReturnValue(mockStorage);
+  });
+
+  describe('login', () => {
+    test('WHEN login is called THEN it returns a fixed self-hosted session', async () => {
+      // Act
+      const response = await provider.login('any@user', 'pw');
+
+      // Assert
+      expect(response).toEqual({
+        data: {
+          user: { email: 'self-hosted@local' },
+          session: { access_token: 'self-hosted-token' },
+        },
+        error: null,
+      });
+    });
+  });
+
+  describe('signUp', () => {
+    test('WHEN signUp is called THEN it delegates to login', async () => {
+      // Act
+      const response = await provider.signUp('a@b', 'pw');
+
+      // Assert
+      expect(response.data.session?.access_token).toBe('self-hosted-token');
+    });
+  });
+
+  describe('getCurrentUser', () => {
+    test('WHEN getCurrentUser is called THEN it returns PRO mock user with stored settings', async () => {
+      // Act
+      const user = await provider.getCurrentUser();
+
+      // Assert
+      expect(user).toEqual({
+        user: { email: 'self-hosted@local' },
+        subscription: {
+          active_from: expect.any(String),
+          active_to: expect.any(String),
+          level: SubscriptionLevel.PRO,
+        },
+        settings: {
+          solutionLanguage: ProgrammingLanguage.JavaScript,
+          userLanguage: UserLanguage.ES_ES,
+        },
+      });
+    });
+  });
+
+  describe('getAuthToken', () => {
+    test('WHEN getAuthToken is called THEN it returns self-hosted-token', async () => {
+      // Act
+      const token = await provider.getAuthToken();
+
+      // Assert
+      expect(token).toBe('self-hosted-token');
+    });
+  });
+
+  describe('isAuthenticated', () => {
+    test('WHEN isAuthenticated is called THEN it returns true', async () => {
+      // Act
+      const result = await provider.isAuthenticated();
+
+      // Assert
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/src/services/auth/index.spec.ts
+++ b/src/services/auth/index.spec.ts
@@ -15,13 +15,10 @@ function loadProvider(selfHosted: boolean): { provider: unknown; ctorName: strin
   let provider: unknown;
   let ctorName = '';
   jest.isolateModules(() => {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const constants = require('../../../shared/constants') as { isSelfHosted: jest.Mock };
     constants.isSelfHosted.mockReturnValue(selfHosted);
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const moduleUnderTest = require('./index') as typeof import('./index');
     provider = moduleUnderTest.getAuthProvider();
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
     ctorName = (provider as any).constructor.name as string;
   });
 
@@ -56,7 +53,6 @@ describe('auth/getAuthProvider', () => {
       let a: unknown;
       let b: unknown;
       jest.isolateModules(() => {
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
         const moduleUnderTest = require('./index') as typeof import('./index');
         a = moduleUnderTest.getAuthProvider();
         b = moduleUnderTest.getAuthProvider();

--- a/src/services/auth/index.spec.ts
+++ b/src/services/auth/index.spec.ts
@@ -1,0 +1,69 @@
+jest.mock('../../../shared/constants', () => ({
+  isSelfHosted: jest.fn(() => false),
+  API_BASE_URL: 'http://localhost:3000',
+}));
+
+jest.mock('../auth', () => ({
+  authService: {},
+}));
+
+jest.mock('../storage', () => ({
+  getStorageProvider: jest.fn(),
+}));
+
+function loadProvider(selfHosted: boolean): { provider: unknown; ctorName: string } {
+  let provider: unknown;
+  let ctorName = '';
+  jest.isolateModules(() => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const constants = require('../../../shared/constants') as { isSelfHosted: jest.Mock };
+    constants.isSelfHosted.mockReturnValue(selfHosted);
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const moduleUnderTest = require('./index') as typeof import('./index');
+    provider = moduleUnderTest.getAuthProvider();
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+    ctorName = (provider as any).constructor.name as string;
+  });
+
+  return { provider, ctorName };
+}
+
+describe('auth/getAuthProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('mode selection', () => {
+    test('WHEN self-hosted is true THEN it returns SelfHostedAuthProvider', () => {
+      // Act
+      const { ctorName } = loadProvider(true);
+
+      // Assert
+      expect(ctorName).toBe('SelfHostedAuthProvider');
+    });
+
+    test('WHEN self-hosted is false THEN it returns ApiAuthProvider', () => {
+      // Act
+      const { ctorName } = loadProvider(false);
+
+      // Assert
+      expect(ctorName).toBe('ApiAuthProvider');
+    });
+  });
+
+  describe('memoization', () => {
+    test('WHEN called twice THEN it returns the same instance', () => {
+      let a: unknown;
+      let b: unknown;
+      jest.isolateModules(() => {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const moduleUnderTest = require('./index') as typeof import('./index');
+        a = moduleUnderTest.getAuthProvider();
+        b = moduleUnderTest.getAuthProvider();
+      });
+
+      // Assert
+      expect(a).toBe(b);
+    });
+  });
+});

--- a/src/services/settings.spec.ts
+++ b/src/services/settings.spec.ts
@@ -1,0 +1,95 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { API_ENDPOINTS, ProgrammingLanguage, UserLanguage } from '../../shared/api';
+import { authService } from './auth';
+import { settingsService } from './settings';
+
+jest.mock('../../shared/constants', () => ({
+  API_BASE_URL: 'http://localhost:3000',
+  isSelfHosted: jest.fn(() => false),
+}));
+
+jest.mock('./auth', () => ({
+  authService: {
+    getAuthToken: jest.fn(),
+  },
+}));
+
+jest.mock('axios');
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const axios = require('axios') as jest.Mocked<typeof import('axios').default>;
+
+describe('settingsService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getSettings', () => {
+    test('WHEN no token is available THEN it throws an error', async () => {
+      (authService.getAuthToken as jest.Mock).mockResolvedValueOnce(null);
+
+      // Act
+      const call = settingsService.getSettings();
+
+      // Assert
+      await expect(call).rejects.toThrow('No authentication token available');
+    });
+
+    test('WHEN token is present THEN it sends Authorization header and returns data', async () => {
+      const data = {
+        solutionLanguage: ProgrammingLanguage.Python,
+        userLanguage: UserLanguage.EN_US,
+      };
+      (authService.getAuthToken as jest.Mock).mockResolvedValueOnce('tok');
+      axios.get.mockResolvedValueOnce({ data });
+
+      // Act
+      const result = await settingsService.getSettings();
+
+      // Assert
+      expect(result).toEqual(data);
+      expect(axios.get).toHaveBeenCalledWith(
+        `http://localhost:3000${API_ENDPOINTS.SETTINGS.GET}`,
+        expect.objectContaining({
+          headers: { Authorization: 'Bearer tok' },
+        }),
+      );
+    });
+  });
+
+  describe('updateSettings', () => {
+    test('WHEN no token is available THEN it throws an error', async () => {
+      (authService.getAuthToken as jest.Mock).mockResolvedValueOnce(null);
+
+      // Act
+      const call = settingsService.updateSettings({
+        solutionLanguage: ProgrammingLanguage.Python,
+        userLanguage: UserLanguage.EN_US,
+      });
+
+      // Assert
+      await expect(call).rejects.toThrow('No authentication token available');
+    });
+
+    test('WHEN token is present THEN it posts settings with Authorization header', async () => {
+      (authService.getAuthToken as jest.Mock).mockResolvedValueOnce('tok');
+      axios.post.mockResolvedValueOnce({ data: undefined });
+      const payload = {
+        solutionLanguage: ProgrammingLanguage.JavaScript,
+        userLanguage: UserLanguage.ES_ES,
+      };
+
+      // Act
+      await settingsService.updateSettings(payload);
+
+      // Assert
+      expect(axios.post).toHaveBeenCalledWith(
+        `http://localhost:3000${API_ENDPOINTS.SETTINGS.UPDATE}`,
+        payload,
+        expect.objectContaining({
+          headers: { Authorization: 'Bearer tok' },
+        }),
+      );
+    });
+  });
+});

--- a/src/services/settings.spec.ts
+++ b/src/services/settings.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/unbound-method */
 import { API_ENDPOINTS, ProgrammingLanguage, UserLanguage } from '../../shared/api';
 import { authService } from './auth';
 import { settingsService } from './settings';
@@ -16,7 +15,6 @@ jest.mock('./auth', () => ({
 
 jest.mock('axios');
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const axios = require('axios') as jest.Mocked<typeof import('axios').default>;
 
 describe('settingsService', () => {

--- a/src/services/storage/LocalStorageProvider.spec.ts
+++ b/src/services/storage/LocalStorageProvider.spec.ts
@@ -1,0 +1,118 @@
+import { AppMode, ProgrammingLanguage, UserLanguage } from '../../../shared/api';
+import { LOCAL_STORAGE_KEYS } from '../../../shared/storage';
+import { LocalStorageProvider } from './LocalStorageProvider';
+
+describe('LocalStorageProvider', () => {
+  let provider: LocalStorageProvider;
+
+  beforeEach(() => {
+    localStorage.clear();
+    provider = new LocalStorageProvider();
+  });
+
+  describe('getSettings', () => {
+    test('WHEN no settings stored THEN it returns Python/EN_US/LIVE_INTERVIEW defaults', async () => {
+      // Act
+      const settings = await provider.getSettings();
+
+      // Assert
+      expect(settings).toEqual({
+        solutionLanguage: ProgrammingLanguage.Python,
+        userLanguage: UserLanguage.EN_US,
+        appMode: AppMode.LIVE_INTERVIEW,
+      });
+    });
+
+    test('WHEN settings are stored THEN it returns parsed values', async () => {
+      localStorage.setItem(
+        LOCAL_STORAGE_KEYS.EZZI_SETTINGS,
+        JSON.stringify({
+          solutionLanguage: ProgrammingLanguage.JavaScript,
+          userLanguage: UserLanguage.ES_ES,
+          appMode: AppMode.LEETCODE_SOLVER,
+        }),
+      );
+
+      // Act
+      const settings = await provider.getSettings();
+
+      // Assert
+      expect(settings).toEqual({
+        solutionLanguage: ProgrammingLanguage.JavaScript,
+        userLanguage: UserLanguage.ES_ES,
+        appMode: AppMode.LEETCODE_SOLVER,
+      });
+    });
+
+    test('WHEN stored payload is malformed THEN it falls back to defaults', async () => {
+      localStorage.setItem(LOCAL_STORAGE_KEYS.EZZI_SETTINGS, '{not-json');
+
+      // Act
+      const settings = await provider.getSettings();
+
+      // Assert
+      expect(settings).toEqual({
+        solutionLanguage: ProgrammingLanguage.Python,
+        userLanguage: UserLanguage.EN_US,
+        appMode: AppMode.LIVE_INTERVIEW,
+      });
+    });
+  });
+
+  describe('updateSettings', () => {
+    test('WHEN partial update applied THEN it merges with existing values', async () => {
+      localStorage.setItem(
+        LOCAL_STORAGE_KEYS.EZZI_SETTINGS,
+        JSON.stringify({
+          solutionLanguage: ProgrammingLanguage.Python,
+          userLanguage: UserLanguage.EN_US,
+          appMode: AppMode.LIVE_INTERVIEW,
+        }),
+      );
+
+      // Act
+      await provider.updateSettings({ solutionLanguage: ProgrammingLanguage.Go });
+
+      // Assert
+      const persisted = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEYS.EZZI_SETTINGS) ?? '{}');
+      expect(persisted).toEqual({
+        solutionLanguage: ProgrammingLanguage.Go,
+        userLanguage: UserLanguage.EN_US,
+        appMode: AppMode.LIVE_INTERVIEW,
+      });
+    });
+  });
+
+  describe('setSolutionLanguage', () => {
+    test('WHEN setSolutionLanguage is called THEN getSolutionLanguage returns it', async () => {
+      // Act
+      await provider.setSolutionLanguage(ProgrammingLanguage.TypeScript);
+      const language = await provider.getSolutionLanguage();
+
+      // Assert
+      expect(language).toBe(ProgrammingLanguage.TypeScript);
+    });
+  });
+
+  describe('setUserLanguage', () => {
+    test('WHEN setUserLanguage is called THEN getUserLanguage returns it', async () => {
+      // Act
+      await provider.setUserLanguage(UserLanguage.JA_JP);
+      const language = await provider.getUserLanguage();
+
+      // Assert
+      expect(language).toBe(UserLanguage.JA_JP);
+    });
+  });
+
+  describe('setAppMode', () => {
+    test('WHEN setAppMode is called THEN getAppMode returns it', async () => {
+      // Act
+      await provider.setAppMode(AppMode.LEETCODE_SOLVER);
+      const mode = await provider.getAppMode();
+
+      // Assert
+      expect(mode).toBe(AppMode.LEETCODE_SOLVER);
+    });
+  });
+});

--- a/src/services/storage/index.spec.ts
+++ b/src/services/storage/index.spec.ts
@@ -1,0 +1,80 @@
+import { SubscriptionLevel } from '../../../shared/api';
+import { isSelfHosted } from '../../../shared/constants';
+import { ApiStorageProvider } from './ApiStorageProvider';
+import { getStorageProvider, resetStorageProvider } from './index';
+import { LocalStorageProvider } from './LocalStorageProvider';
+
+jest.mock('../../../shared/constants', () => ({
+  isSelfHosted: jest.fn(() => false),
+  API_BASE_URL: 'http://localhost:3000',
+}));
+
+describe('storage/getStorageProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetStorageProvider();
+    (isSelfHosted as jest.MockedFunction<typeof isSelfHosted>).mockReturnValue(false);
+  });
+
+  describe('mode selection', () => {
+    test('WHEN self-hosted mode is on THEN it returns LocalStorageProvider', () => {
+      (isSelfHosted as jest.MockedFunction<typeof isSelfHosted>).mockReturnValue(true);
+
+      // Act
+      const provider = getStorageProvider();
+
+      // Assert
+      expect(provider).toBeInstanceOf(LocalStorageProvider);
+    });
+
+    test('WHEN subscription is FREE THEN it returns LocalStorageProvider', () => {
+      // Act
+      const provider = getStorageProvider(SubscriptionLevel.FREE);
+
+      // Assert
+      expect(provider).toBeInstanceOf(LocalStorageProvider);
+    });
+
+    test('WHEN subscription is PRO THEN it returns ApiStorageProvider', () => {
+      // Act
+      const provider = getStorageProvider(SubscriptionLevel.PRO);
+
+      // Assert
+      expect(provider).toBeInstanceOf(ApiStorageProvider);
+    });
+
+    test('WHEN subscription level changes THEN provider is recreated', () => {
+      const free = getStorageProvider(SubscriptionLevel.FREE);
+
+      // Act
+      const pro = getStorageProvider(SubscriptionLevel.PRO);
+
+      // Assert
+      expect(free).not.toBe(pro);
+      expect(pro).toBeInstanceOf(ApiStorageProvider);
+    });
+  });
+
+  describe('memoization', () => {
+    test('WHEN called twice with same level THEN it returns the same instance', () => {
+      const a = getStorageProvider(SubscriptionLevel.PRO);
+
+      // Act
+      const b = getStorageProvider(SubscriptionLevel.PRO);
+
+      // Assert
+      expect(a).toBe(b);
+    });
+
+    test('WHEN resetStorageProvider is called THEN next call rebuilds provider', () => {
+      const a = getStorageProvider(SubscriptionLevel.PRO);
+
+      // Act
+      resetStorageProvider();
+      const b = getStorageProvider(SubscriptionLevel.PRO);
+
+      // Assert
+      expect(a).not.toBe(b);
+    });
+  });
+});

--- a/src/utils/electron.spec.ts
+++ b/src/utils/electron.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/unbound-method */
 jest.mock('../../shared/constants', () => ({
   isSelfHosted: jest.fn(() => false),
   API_BASE_URL: 'http://localhost:3000',
@@ -35,15 +34,12 @@ describe('sendToElectron', () => {
       handleCloseClick: jest.fn().mockResolvedValue(undefined),
       handleQueueLoadedNoScreenshots: jest.fn(),
       handleQueueLoadedWithScreenshots: jest.fn(),
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any).electron = { ipcRenderer: {} };
   });
 
   afterEach(() => {
     consoleErrorSpy.mockRestore();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     delete (window as any).electron;
   });
 
@@ -93,7 +89,6 @@ describe('sendToElectron', () => {
 
   describe('missing electron bridge', () => {
     test('WHEN window.electron is missing THEN it logs an error and skips IPC', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       delete (window as any).electron;
 
       // Act

--- a/src/utils/electron.spec.ts
+++ b/src/utils/electron.spec.ts
@@ -1,0 +1,107 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+jest.mock('../../shared/constants', () => ({
+  isSelfHosted: jest.fn(() => false),
+  API_BASE_URL: 'http://localhost:3000',
+  IPC_EVENTS: {
+    TOOLTIP: {
+      MOUSE_ENTER: 'tooltip:mouse-enter',
+      MOUSE_LEAVE: 'tooltip:mouse-leave',
+      CLOSE_CLICK: 'tooltip:close-click',
+    },
+    QUEUE: {
+      LOADED_NO_SCREENSHOTS: 'queue:loaded-no-screenshots',
+      LOADED_WITH_SCREENSHOTS: 'queue:loaded-with-screenshots',
+    },
+    APP_MODE: {
+      CHANGE: 'app-mode:change',
+    },
+  },
+}));
+
+import { IPC_EVENTS } from '../../shared/constants';
+import { sendToElectron } from './electron';
+
+describe('sendToElectron', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    window.electronAPI = {
+      ...window.electronAPI,
+      handleMouseEnter: jest.fn().mockResolvedValue(undefined),
+      handleMouseLeave: jest.fn().mockResolvedValue(undefined),
+      handleCloseClick: jest.fn().mockResolvedValue(undefined),
+      handleQueueLoadedNoScreenshots: jest.fn(),
+      handleQueueLoadedWithScreenshots: jest.fn(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).electron = { ipcRenderer: {} };
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).electron;
+  });
+
+  describe('TOOLTIP events', () => {
+    test('WHEN MOUSE_ENTER channel is sent THEN handleMouseEnter is called', () => {
+      // Act
+      sendToElectron(IPC_EVENTS.TOOLTIP.MOUSE_ENTER, 'arg');
+
+      // Assert
+      expect(window.electronAPI.handleMouseEnter).toHaveBeenCalled();
+    });
+
+    test('WHEN MOUSE_LEAVE channel is sent THEN handleMouseLeave is called', () => {
+      // Act
+      sendToElectron(IPC_EVENTS.TOOLTIP.MOUSE_LEAVE);
+
+      // Assert
+      expect(window.electronAPI.handleMouseLeave).toHaveBeenCalled();
+    });
+
+    test('WHEN CLOSE_CLICK channel is sent THEN handleCloseClick is called', () => {
+      // Act
+      sendToElectron(IPC_EVENTS.TOOLTIP.CLOSE_CLICK);
+
+      // Assert
+      expect(window.electronAPI.handleCloseClick).toHaveBeenCalled();
+    });
+  });
+
+  describe('QUEUE events', () => {
+    test('WHEN LOADED_NO_SCREENSHOTS channel is sent THEN handler is called', () => {
+      // Act
+      sendToElectron(IPC_EVENTS.QUEUE.LOADED_NO_SCREENSHOTS);
+
+      // Assert
+      expect(window.electronAPI.handleQueueLoadedNoScreenshots).toHaveBeenCalled();
+    });
+
+    test('WHEN LOADED_WITH_SCREENSHOTS channel is sent THEN handler receives count', () => {
+      // Act
+      sendToElectron(IPC_EVENTS.QUEUE.LOADED_WITH_SCREENSHOTS, 3);
+
+      // Assert
+      expect(window.electronAPI.handleQueueLoadedWithScreenshots).toHaveBeenCalledWith(3);
+    });
+  });
+
+  describe('missing electron bridge', () => {
+    test('WHEN window.electron is missing THEN it logs an error and skips IPC', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      delete (window as any).electron;
+
+      // Act
+      sendToElectron(IPC_EVENTS.TOOLTIP.MOUSE_ENTER);
+
+      // Assert
+      expect(consoleErrorSpy).toHaveBeenCalledWith('No Electron window available!');
+      expect(window.electronAPI.handleMouseEnter).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Adds 14 new spec files (111 tests across 16 suites) covering critical paths that were previously untested.

Electron main:
- app.storage (singleton, appMode, readableVarNames)
- LiveInterviewProcessor / LeetCodeProcessor (success, 401, 402, cancel, missing conversationId)
- AppModeProcessorFactory (mapping, fallback, dynamic register)
- WindowConfigFactory (config selection per AppMode)

Renderer:
- LocalStorageProvider (parse, defaults, malformed JSON, partial updates)
- storage/getStorageProvider (self-hosted/FREE/PRO switching, memoization, reset)
- auth/getAuthProvider (mode switching, memoization)
- SelfHostedAuthProvider (mock user with stored settings)
- authService (login, signUp, getCurrentUser, getAuthToken edge cases)
- settingsService (token error handling, Authorization header)
- sendToElectron (channel routing, missing electron bridge)
- ScreenshotContext + SolutionContext reducers